### PR TITLE
have pyproject.toml build depend on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,5 @@ cffi = "^1.14.2"
 pytest = "^6.0.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["setuptools", "poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
I've been trying to build a poetry-based package which _depends_ on this one and I consistently would get the following build error until I added `"setuptools"` explicitly to the `require` section in the `[build-system]` portion of the `pyproject.toml`:

```
   • Installing pqcrypto (0.1.3 /..../pqcrypto)
 
   EnvCommandError
 
   Command ['/home/..../.cache/pypoetry/virtualenvs/..../bin/pip', 'install', '--no-deps', '-U', '-e', '/..../pqcrypto'] errored with the following return code 1, and output: 
   Obtaining file:///..../pqcrypto
     Installing build dependencies: started
     Installing build dependencies: finished with status 'done'
     Checking if build backend supports build_editable: started
     Checking if build backend supports build_editable: finished with status 'done'
     Getting requirements to build wheel: started
     Getting requirements to build wheel: finished with status 'done'
     Preparing metadata (pyproject.toml): started
     Preparing metadata (pyproject.toml): finished with status 'done'
   Installing collected packages: pqcrypto
     Running setup.py develop for pqcrypto
       ERROR: Command errored out with exit status 1:
        command: /home/..../.cache/pypoetry/virtualenvs/..../bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/..../pqcrypto/setup.py'"'"'; __file__='"'"'/..../pqcrypto/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps
            cwd: /..../pqcrypto/
       Complete output (3 lines):
       Traceback (most recent call last):
         File "<string>", line 1, in <module>
       ModuleNotFoundError: No module named 'setuptools'
```

I don't have any deep insights to add beyond "this seems to fix the issue I was experiencing". Not sure why I don't also see it when _just_ trying to build the `pqcrypto` package itself.